### PR TITLE
add files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.9",
   "description": "js drawing guestbook",
   "main": "dist/bundle.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "webpack",
     "watch": "webpack --watch",


### PR DESCRIPTION
If you look [here](https://unpkg.com/squarebook@1.1.9/) you'll notice that there are several files included with this package on the registry that don't need to be. This causes npm installs of this module to result in downloading more than necessary.

By adding this [`files`](https://docs.npmjs.com/files/package.json#files) array to `package.json` you can specifically list the files that are important for people to download for your module. By default, npm will also include `README` and `LICENSE` files as well.
